### PR TITLE
Fix --open NameError

### DIFF
--- a/scroller.py
+++ b/scroller.py
@@ -172,7 +172,7 @@ def main(string=None, args=None):
             try:
                 for permutation in scroller(string,
                                             static,
-                                            count,
+                                            args.count,
                                             args.reverse,
                                             args.sep):
                     r, _, _ = select.select([sys.stdin], [], [], 0)


### PR DESCRIPTION
`scroller -o` currently produces a NameError, since `count` referenced in
scroller.py:175 is not defíned anymore. There was some logic in place which
initialized it from args.count, but it was removed in a0d94abc.